### PR TITLE
Little fix for a IE transparency/click bug

### DIFF
--- a/jquery.css3finalize.js
+++ b/jquery.css3finalize.js
@@ -547,6 +547,7 @@
 						if (property.toUpperCase() === 'BACKGROUND-COLOR' && value.indexOf('rgba') === 0) {
 							value = ac2ah(value);
 							return {
+								'background' : "url(#)",
 								'filter' : "progid:DXImageTransform.Microsoft.gradient(startColorStr='" + value + "',EndColorStr='" + value + "')"
 							};
 						}
@@ -555,6 +556,7 @@
 							var da = value.replace(/^linear-gradient\s?\(\s?(.*?)\s?\)$/, '$1').split(/,\s?/);
 							if (da.length == 2) {
 								return {
+									'background' : "url(#)",
 									'filter' : "progid:DXImageTransform.Microsoft.gradient(startColorStr='" + da[0] + "',EndColorStr='" + da[1] + "')"
 								};
 							}


### PR DESCRIPTION
I just found a little annoying bug with the IE filter technique that produce some unexpected behavior.

Sounds IE does not consider transparent area when selected by Filter as clickable. As consequence it does not capture the click. It's really annoying when you have an overlay for a popup for example.
I found a easy way to fix it here : http://haslayout.net/css/No-Transparency-Click-Bug 
And added it to the library :).

I was wondering about pointer property.... On my side what I did was to force cursor to be default on the overlay without adding it to the finalize script. 
I guess it could be considered as not relevant of stuff that should be done by the script.
